### PR TITLE
Fix Mac OS in a Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ macos_task:
   osx_instance:
     image: mojave-base
   install_script:
-    - brew cask install osxfuse
+    - brew install --cask osxfuse
     - brew install cmake
   test_script:
     - cmake -S . -B build


### PR DESCRIPTION
brew failed to call cask install directly,
one should use brew install [--cask] instead.