### PR TITLE
Fix build on FreeBSD and macOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,11 +3,12 @@ freebsd_task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64
   install_script:
-    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f; pkg install -y cmake fusefs-libs
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f; pkg install -y cmake fusefs-libs pkgconf
     - kldload fuse
     - kldstat
   test_script:
     - cmake -S . -B build
+    - cmake --build build
 
 macos_catalina_task:
   name: macOS Catalina
@@ -18,6 +19,7 @@ macos_catalina_task:
     - brew install cmake
   test_script:
     - cmake -S . -B build
+    - cmake --build build
 
 macos_bigsur_task:
   name: macOS Big Sur
@@ -30,3 +32,4 @@ macos_bigsur_task:
     - brew install cmake
   test_script:
     - cmake -S . -B build
+    - cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D_FILE_OFFSET_BITS=64")
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 find_package(FUSE 2.9 REQUIRED)
 
-include_directories(${FUSE_INCLUDE_DIR})
+add_definitions(${FUSE_DEFINITIONS})
 add_executable(${PROJECT_NAME} ${UNRELIABLEFS_SRC})
+target_include_directories(${PROJECT_NAME} PRIVATE ${FUSE_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${FUSE_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Prerequisites:
 
 - CentOS: `dnf install -y gcc -y cmake fuse fuse-devel`
 - Ubuntu: `apt-get install -y gcc cmake fuse libfuse-dev`
-- FreeBSD: `pkg install gcc cmake fusefs-libs`
+- FreeBSD: `pkg install gcc cmake fusefs-libs pkgconf`
 - OpenBSD: `pkg_add cmake`
 - macOS: `brew install --cask osxfuse`
 

--- a/cmake/FindFUSE.cmake
+++ b/cmake/FindFUSE.cmake
@@ -1,7 +1,7 @@
 # This module can find FUSE Library
 #
 # Requirements:
-# - CMake >= 2.8.3
+# - CMake >= 3.12.4
 #
 # The following variables will be defined for your use:
 # - FUSE_FOUND : was FUSE found?
@@ -38,7 +38,7 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #=============================================================================
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.12.4)
 
 ########## Private ##########
 function(fusedebug _varname)

--- a/cmake/FindFUSE.cmake
+++ b/cmake/FindFUSE.cmake
@@ -119,6 +119,7 @@ if(FUSE_FOUND)
     set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}" "${FUSE_LIBRARIES}")
     set(CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}" "${FUSE_DEFINITIONS}")
     check_c_source_compiles("#include <stdlib.h>
+#define FUSE_USE_VERSION 29
 #include <fuse.h>
 #include <stdio.h>
 #include <string.h>

--- a/unreliablefs.c
+++ b/unreliablefs.c
@@ -29,7 +29,7 @@ static struct fuse_operations unreliable_ops = {
     .flush       = unreliable_flush,
     .release     = unreliable_release,
     .fsync       = unreliable_fsync,
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
     .setxattr    = unreliable_setxattr,
     .getxattr    = unreliable_getxattr,
     .listxattr   = unreliable_listxattr,
@@ -48,7 +48,7 @@ static struct fuse_operations unreliable_ops = {
     .ftruncate   = unreliable_ftruncate,
     .fgetattr    = unreliable_fgetattr,
     .lock        = unreliable_lock,
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
     .ioctl       = unreliable_ioctl,
     .flock       = unreliable_flock,
     .fallocate   = unreliable_fallocate,

--- a/unreliablefs_errinj.c
+++ b/unreliablefs_errinj.c
@@ -1,7 +1,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 #define MAX_ERR EXFULL
 #else
 #define MAX_ERR ELAST

--- a/unreliablefs_ops.c
+++ b/unreliablefs_ops.c
@@ -9,7 +9,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/file.h>
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <sys/xattr.h>
 #endif /* __OpenBSD__ */
 
@@ -330,7 +330,7 @@ int unreliable_fsync(const char *path, int datasync, struct fuse_file_info *fi)
     return 0;
 }
 
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_setxattr(const char *path, const char *name,
                      const char *value, size_t size, int flags)
 {
@@ -348,7 +348,7 @@ int unreliable_setxattr(const char *path, const char *name,
 }
 #endif /* __OpenBSD__ */
 
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_getxattr(const char *path, const char *name,
                      char *value, size_t size)
 {
@@ -366,7 +366,7 @@ int unreliable_getxattr(const char *path, const char *name,
 }
 #endif /* __OpenBSD__ */
 
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_listxattr(const char *path, char *list,
                       size_t size)
 {
@@ -384,7 +384,7 @@ int unreliable_listxattr(const char *path, char *list,
 }
 #endif /* __OpenBSD__ */
 
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_removexattr(const char *path, const char *name)
 {
     int ret = error_inject(path, "removexattr");
@@ -614,7 +614,7 @@ int unreliable_flock(const char *path, struct fuse_file_info *fi, int op)
 }
 #endif /* __OpenBSD__ */
 
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_fallocate(const char *path, int mode,
                       off_t offset, off_t len,
                       struct fuse_file_info *fi)

--- a/unreliablefs_ops.h
+++ b/unreliablefs_ops.h
@@ -1,6 +1,8 @@
 #ifndef UNRELIABLEFS_OPS_HH
 #define UNRELIABLEFS_OPS_HH
 
+#define FUSE_USE_VERSION 29
+
 #include <fuse.h>
 
 int unreliable_getattr(const char *, struct stat *);
@@ -24,7 +26,7 @@ int unreliable_statfs(const char *, struct statvfs *);
 int unreliable_flush(const char *, struct fuse_file_info *);
 int unreliable_release(const char *, struct fuse_file_info *);
 int unreliable_fsync(const char *, int, struct fuse_file_info *);
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
 int unreliable_setxattr(const char *, const char *, const char *, size_t, int);
 int unreliable_getxattr(const char *, const char *, char *, size_t);
 int unreliable_listxattr(const char *, char *, size_t);
@@ -46,7 +48,7 @@ int unreliable_ftruncate(const char *, off_t, struct fuse_file_info *);
 int unreliable_fgetattr(const char *, struct stat *, struct fuse_file_info *);
 int unreliable_lock(const char *, struct fuse_file_info *, int cmd,
                  struct flock *);
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_ioctl(const char *, int cmd, void *arg,
                   struct fuse_file_info *, unsigned int flags, void *data);
 #endif /* __OpenBSD__ */
@@ -54,7 +56,7 @@ int unreliable_write_buf(const char *, struct fuse_bufvec *buf, off_t off,
                       struct fuse_file_info *);
 int unreliable_read_buf(const char *, struct fuse_bufvec **bufp,
                      size_t size, off_t off, struct fuse_file_info *);
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 int unreliable_flock(const char *, struct fuse_file_info *, int op);
 int unreliable_fallocate(const char *, int, off_t, off_t,
                       struct fuse_file_info *);


### PR DESCRIPTION
Accidentally commands to build a project has been missed for build jobs
on FreeBSD and macOS in a Cirrus CI config file. Patch fixes it and fix
source to be make it possible to build on these operating systems.