### PR TITLE
Use HAVE_XATTR in unreliablefs.c

### DIFF
--- a/unreliablefs.c
+++ b/unreliablefs.c
@@ -29,12 +29,12 @@ static struct fuse_operations unreliable_ops = {
     .flush       = unreliable_flush,
     .release     = unreliable_release,
     .fsync       = unreliable_fsync,
-#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__)
+#ifdef HAVE_XATTR
     .setxattr    = unreliable_setxattr,
     .getxattr    = unreliable_getxattr,
     .listxattr   = unreliable_listxattr,
     .removexattr = unreliable_removexattr,
-#endif /* __OpenBSD__ */
+#endif /* HAVE_XATTR */
     .opendir     = unreliable_opendir,
     .readdir     = unreliable_readdir,
     .releasedir  = unreliable_releasedir,


### PR DESCRIPTION
In commit c96dbe41b2f53fb5a9ac1e0fc798775c9cd01596 ("Use
check_function_exists() to detect functions support") macroses
for operating systems has been replaced by macroses for features.
One place was missed and patch fixes it.