### PR TITLE
Disable FUSE wrapper for ioctl() on OpenBSD

### DIFF
--- a/unreliablefs.c
+++ b/unreliablefs.c
@@ -48,7 +48,9 @@ static struct fuse_operations unreliable_ops = {
     .ftruncate   = unreliable_ftruncate,
     .fgetattr    = unreliable_fgetattr,
     .lock        = unreliable_lock,
+#if !defined(__OpenBSD__)
     .ioctl       = unreliable_ioctl,
+#endif /* __OpenBSD__ */
 #ifdef HAVE_FLOCK
     .flock       = unreliable_flock,
 #endif /* HAVE_FLOCK */

--- a/unreliablefs_ops.c
+++ b/unreliablefs_ops.c
@@ -626,6 +626,7 @@ int unreliable_lock(const char *path, struct fuse_file_info *fi, int cmd,
     return 0;
 }
 
+#if !defined(__OpenBSD__)
 int unreliable_ioctl(const char *path, int cmd, void *arg,
                      struct fuse_file_info *fi,
                      unsigned int flags, void *data)
@@ -642,6 +643,7 @@ int unreliable_ioctl(const char *path, int cmd, void *arg,
     
     return ret;
 }
+#endif /* __OpenBSD__ */
 
 #ifdef HAVE_FLOCK
 int unreliable_flock(const char *path, struct fuse_file_info *fi, int op)

--- a/unreliablefs_ops.h
+++ b/unreliablefs_ops.h
@@ -50,8 +50,10 @@ int unreliable_ftruncate(const char *, off_t, struct fuse_file_info *);
 int unreliable_fgetattr(const char *, struct stat *, struct fuse_file_info *);
 int unreliable_lock(const char *, struct fuse_file_info *, int cmd,
                  struct flock *);
+#if !defined(__OpenBSD__)
 int unreliable_ioctl(const char *, int cmd, void *arg,
                   struct fuse_file_info *, unsigned int flags, void *data);
+#endif
 int unreliable_write_buf(const char *, struct fuse_bufvec *buf, off_t off,
                       struct fuse_file_info *);
 int unreliable_read_buf(const char *, struct fuse_bufvec **bufp,


### PR DESCRIPTION
OpenBSD has it's own FUSE implementation that
doesn't support ioctl() operation.

In file included from /home/sergeyb/source/unreliablefs/unreliablefs.c:10:
/home/sergeyb/source/unreliablefs/unreliablefs_ops.h:55:47: warning: declaration of 'struct fuse_bufvec' will not be visible outside of this
      function [-Wvisibility]
int unreliable_write_buf(const char *, struct fuse_bufvec *buf, off_t off,
                                              ^
/home/sergeyb/source/unreliablefs/unreliablefs_ops.h:57:46: warning: declaration of 'struct fuse_bufvec' will not be visible outside of this
      function [-Wvisibility]
int unreliable_read_buf(const char *, struct fuse_bufvec **bufp,
                                             ^
/home/sergeyb/source/unreliablefs/unreliablefs.c:51:6: error: field designator 'ioctl' does not refer to any field in type
      'struct fuse_operations'
    .ioctl       = unreliable_ioctl,
     ^
2 warnings and 1 error generated.

Disable ioctl() enabled in commit c96dbe41b2f53fb5a9ac1e0fc798775c9cd01596
("Use check_function_exists() to detect functions support").