### PR TITLE
Allow arbitrary large duration option

### DIFF
--- a/unreliablefs/unreliablefs_errinj.c
+++ b/unreliablefs/unreliablefs_errinj.c
@@ -222,13 +222,14 @@ int error_inject(const char* path, fuse_op operation)
             rc = -rc;
             break;
         case ERRINJ_SLOWDOWN: ;
-	    struct timespec ts = {};
-	    ts.tv_nsec = err->duration;
-            fprintf(stdout, "start of '%s' slowdown for '%d' ns\n", op_name, err->duration);
+	    struct timespec ts;
+	    ts.tv_sec = err->duration / 1000000000;
+	    ts.tv_nsec = err->duration % 1000000000;
+            fprintf(stdout, "start of '%s' slowdown for '%llu' ns\n", op_name, err->duration);
             if (nanosleep(&ts, NULL) != 0) {
 		perror("nanosleep");
             } else {
-		fprintf(stdout, "end of '%s' slowdown with '%d' ns\n", op_name, err->duration);
+		fprintf(stdout, "end of '%s' slowdown with '%llu' ns\n", op_name, err->duration);
             }
             break;
         }
@@ -328,7 +329,7 @@ int conf_option_handler(void* cfg, const char* section,
     } else if (strcmp(key, "probability") == 0) {
         err->probability = atoi(value);
     } else if (strcmp(key, "duration") == 0) {
-        err->duration = atoi(value);
+        err->duration = atoll(value);
     } else {
         fprintf(stderr, "unknown option '%s' in configuration file\n", key);
         return 0;

--- a/unreliablefs/unreliablefs_errinj.h
+++ b/unreliablefs/unreliablefs_errinj.h
@@ -54,7 +54,7 @@ struct errinj_conf {
     char *path_regexp;
     char *errno_regexp;
     unsigned int probability;
-    unsigned int duration;
+    unsigned long long duration;
     errinj_type type;
 
     TAILQ_ENTRY(errinj_conf) entries;


### PR DESCRIPTION
`nanosleep()` fails if `.tv_nsec` is larger than 999999999, so duration must be distributed between `.tv_sec` and `.tv_nsec`.  Duration also needs to be stored in `unsigned long long` to be able to store values of more than ~4 seconds.